### PR TITLE
Fix/Seed-data

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,27 +1,28 @@
 {
-    "parserOptions": {
-        "ecmaVersion": 9,
-        "sourceType": "module"
-    },
-    "env": {
-        "node": true,
-        "jest": true
-    },
-    "extends": ["eslint:recommended"],
-    "rules": {
-        "no-console": "warn",
-        "indent": [
-            "error",
-            4,
-            {
-                "SwitchCase": 1
-            }
-        ],
-        "semi": ["error", "always"],
-        "space-in-parens": ["error"],
-        "space-infix-ops": "error",
-        "object-curly-spacing": ["error", "always"],
-        "comma-spacing": "error",
-        "array-bracket-spacing": "error"
-    }
+  "parserOptions": {
+    "ecmaVersion": 9,
+    "sourceType": "module"
+  },
+  "env": {
+    "node": true,
+    "jest": true
+  },
+  "extends": ["eslint:recommended"],
+  "rules": {
+    "no-console": "warn",
+    "indent": [
+      "error",
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "semi": ["error", "always"],
+    "space-in-parens": ["error"],
+    "space-infix-ops": "error",
+    "object-curly-spacing": ["error", "always"],
+    "comma-spacing": "error",
+    "array-bracket-spacing": "error",
+    "no-undef": "off"
+  }
 }

--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -1,196 +1,204 @@
 const pool = require('../lib/utils/pool.js');
-const setup = require('../data/setup.js');
 const request = require('supertest');
+const { execSync } = require('child_process');
 
 const app = require('../lib/app.js');
 
-describe.skip('character routes', () => {
-    beforeEach(() => {
-        return setup(pool);
-    });
+describe('character routes', () => {
+  beforeAll(() => {
+    execSync('npm run setup-db');
+  });
 
-    afterAll(() => {
-        pool.end();
-    });
+  afterAll(() => {
+    pool.end();
+  });
 
-    it.only('returns all characters', async () => {
-        const allChar = [
-            {
-                id: 1,
-                name: 'Michael',
-                fullName: 'Michael Bluth',
-                aliases: 'Nichael Bluth, Chareth Cutestory',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/f/f7/1x01_Pilot_%2809%29.png/revision/latest?cb=20120301043946',
-                actor: 'Jason Bateman',
-            },
-            {
-                id: 2,
-                name: 'Lindsay',
-                fullName: 'Lindsay Bluth Fünke',
-                aliases: 'Nellie Sitwell',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/8/8d/Season_1_Character_Promos_-_Lindsay_Bluth_F%C3%BCnke_03.jpeg/revision/latest?cb=20120429230807',
-                actor: 'Portia de Rossi',
-            },
-            {
-                id: 3,
-                name: 'Gob',
-                fullName: "George Oscar 'GOB' Bluth, Jr.",
-                aliases: 'G.O.B.',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/0/02/Season_1_Character_Promos_-_G.O.B.jpeg/revision/latest?cb=20120429230530',
-                actor: 'Will Arnett',
-            },
-            {
-                id: 4,
-                name: 'George Michael',
-                fullName: 'George Michael Bluth',
-                aliases: 'George Maharis, Mr. Manager',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c3/Season_1_Character_Promos_-_George_Michael_Bluth_02.jpeg/revision/latest?cb=20120429230332',
-                actor: 'Michael Cera',
-            },
-            {
-                id: 5,
-                name: 'Maeby',
-                fullName: 'Maeby Fünke',
-                aliases: 'Surely',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c2/Season_1_Character_Promos_-_Maeby_F%C3%BCnke_02.jpeg/revision/latest?cb=20120429230807',
-                actor: 'Alia Shawkat',
-            },
-            {
-                id: 6,
-                name: 'Buster',
-                fullName: "Byron 'Buster' Bluth",
-                aliases: 'Baby Buster',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/e/e3/Season_1_Character_Promos_-_Buster_Bluth_02.jpeg/revision/latest?cb=20120429230331',
-                actor: 'Tony Hale',
-            },
-            {
-                id: 7,
-                name: 'Tobias',
-                fullName: 'Dr. Tobias Onyango Fünke',
-                aliases: 'Frightened Inmate #2, Mrs. Featherbottom',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/0/0a/Season_1_Character_Promos_-_Tobias_F%C3%BCnke_02.jpeg/revision/latest?cb=20120429230332',
-                actor: 'David Cross',
-            },
-            {
-                id: 8,
-                name: 'George',
-                fullName: 'George Oscar Bluth, Sr.',
-                aliases: 'Pop-pop, Prisoner # 1881372911',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/4/40/Season_1_Character_Promos_-_George_Bluth_03.jpeg/revision/latest?cb=20120429230332',
-                actor: 'Jeffrey Tambor',
-            },
-            {
-                id: 9,
-                name: 'Lucille',
-                fullName: 'Lucille Bluth',
-                aliases: 'Lucille 1, Gange',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/4/49/Season_1_Character_Promos_-_Lucille_Bluth_02.jpeg/revision/latest?cb=20120429230529',
-                actor: 'Jessica Walter',
-            },
-            {
-                id: 10,
-                name: 'Lucille Austero',
-                fullName: 'Lucille Austero',
-                aliases: 'Lucille 2',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/7/76/1x08_My_Mother_the_Car_%2833%29.png/revision/latest/scale-to-width-down/1000?cb=20120214071637',
-                actor: 'Liza Minelli',
-            },
-            {
-                id: 11,
-                name: 'Barry',
-                fullName: 'Barry Zuckerkorn',
-                aliases: 'Barry',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/5/5a/4x01_Flight_of_the_Phoenix_%28072%29.png/revision/latest/scale-to-width-down/1000?cb=20130601035017',
-                actor: 'Henry Winkler',
-            },
-            {
-                id: 12,
-                name: 'Kitty',
-                fullName: 'Kitty Sanchez',
-                aliases: 'Kitty',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/7/72/1x18_Missing_Kitty_%2818%29.png/revision/latest/scale-to-width-down/1000?cb=20120819205717',
-                actor: 'Judy Greer',
-            },
-            {
-                id: 13,
-                name: 'Ann',
-                fullName: 'Annabelle Paul Veal',
-                aliases: 'Her?, Bland, Egg, Plant, Who?, Ann Hog, Plain',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/1/16/2x11_Out_on_a_Limb_%2816%29.png/revision/latest/scale-to-width-down/1000?cb=20130123232423',
-                actor: 'Mae Whitman',
-            },
-            {
-                id: 14,
-                name: 'Steve Holt',
-                fullName: 'Steve Holt',
-                aliases: 'Steve',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/b/b4/1x03_Bringing_Up_Buster_%2831%29.png/revision/latest/scale-to-width-down/1000?cb=20120123071546',
-                actor: 'Justin Grant Wade',
-            },
-            {
-                id: 15,
-                name: 'Oscar',
-                fullName: 'Oscar George Bluth',
-                aliases: 'Oscar',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/6/69/2x07_Switch_Hitter_%2812%29.png/revision/latest/scale-to-width-down/1000?cb=20121216214633',
-                actor: 'Jeffrey Tambor',
-            },
-            {
-                id: 16,
-                name: 'Annyong',
-                fullName: "Hel-loh 'Annyong' Bluth",
-                aliases: 'Annyong',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c0/1x18_Missing_Kitty_%2828%29.png/revision/latest/scale-to-width-down/1000?cb=20120819210411',
-                actor: 'Justin Lee',
-            },
-            {
-                id: 17,
-                name: 'J. Walter Weatherman',
-                fullName: 'J. Walter Weatherman',
-                aliases: 'J, The one-armed man',
-                pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/6/66/1x10_Pier_Pressure_%2840%29.png/revision/latest/scale-to-width-down/1000?cb=20120229061140',
-                actor: 'Steve Ryan',
-            },
-        ];
+  it('returns all characters', async () => {
+    const allChar = [
+      {
+        id: 1,
+        name: 'Michael',
+        fullName: 'Michael Bluth',
+        aliases: 'Nichael Bluth, Chareth Cutestory',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/f/f7/1x01_Pilot_%2809%29.png/revision/latest?cb=20120301043946',
+        actor: 'Jason Bateman',
+      },
+      {
+        id: 2,
+        name: 'Lindsay',
+        fullName: 'Lindsay Bluth Fünke',
+        aliases: 'Nellie Sitwell',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/8/8d/Season_1_Character_Promos_-_Lindsay_Bluth_F%C3%BCnke_03.jpeg/revision/latest?cb=20120429230807',
+        actor: 'Portia de Rossi',
+      },
+      {
+        id: 3,
+        name: 'Gob',
+        fullName: "George Oscar 'GOB' Bluth, Jr.",
+        aliases: 'G.O.B.',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/0/02/Season_1_Character_Promos_-_G.O.B.jpeg/revision/latest?cb=20120429230530',
+        actor: 'Will Arnett',
+      },
+      {
+        id: 4,
+        name: 'George Michael',
+        fullName: 'George Michael Bluth',
+        aliases: 'George Maharis, Mr. Manager',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c3/Season_1_Character_Promos_-_George_Michael_Bluth_02.jpeg/revision/latest?cb=20120429230332',
+        actor: 'Michael Cera',
+      },
+      {
+        id: 5,
+        name: 'Maeby',
+        fullName: 'Maeby Fünke',
+        aliases: 'Surely',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c2/Season_1_Character_Promos_-_Maeby_F%C3%BCnke_02.jpeg/revision/latest?cb=20120429230807',
+        actor: 'Alia Shawkat',
+      },
+      {
+        id: 6,
+        name: 'Buster',
+        fullName: "Byron 'Buster' Bluth",
+        aliases: 'Baby Buster',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/e/e3/Season_1_Character_Promos_-_Buster_Bluth_02.jpeg/revision/latest?cb=20120429230331',
+        actor: 'Tony Hale',
+      },
+      {
+        id: 7,
+        name: 'Tobias',
+        fullName: 'Dr. Tobias Onyango Fünke',
+        aliases: 'Frightened Inmate #2, Mrs. Featherbottom',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/0/0a/Season_1_Character_Promos_-_Tobias_F%C3%BCnke_02.jpeg/revision/latest?cb=20120429230332',
+        actor: 'David Cross',
+      },
+      {
+        id: 8,
+        name: 'George',
+        fullName: 'George Oscar Bluth, Sr.',
+        aliases: 'Pop-pop, Prisoner # 1881372911',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/4/40/Season_1_Character_Promos_-_George_Bluth_03.jpeg/revision/latest?cb=20120429230332',
+        actor: 'Jeffrey Tambor',
+      },
+      {
+        id: 9,
+        name: 'Lucille',
+        fullName: 'Lucille Bluth',
+        aliases: 'Lucille 1, Gange',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/4/49/Season_1_Character_Promos_-_Lucille_Bluth_02.jpeg/revision/latest?cb=20120429230529',
+        actor: 'Jessica Walter',
+      },
+      {
+        id: 10,
+        name: 'Barry',
+        fullName: 'Barry Zuckerkorn',
+        aliases: 'Barry',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/5/5a/4x01_Flight_of_the_Phoenix_%28072%29.png/revision/latest/scale-to-width-down/1000?cb=20130601035017',
+        actor: 'Henry Winkler',
+      },
+      {
+        id: 11,
+        name: 'Kitty',
+        fullName: 'Kitty Sanchez',
+        aliases: 'Kitty',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/7/72/1x18_Missing_Kitty_%2818%29.png/revision/latest/scale-to-width-down/1000?cb=20120819205717',
+        actor: 'Judy Greer',
+      },
+      {
+        id: 12,
+        name: 'Ann',
+        fullName: 'Annabelle Paul Veal',
+        aliases: 'Her?, Bland, Egg, Plant, Who?, Ann Hog, Plain',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/1/16/2x11_Out_on_a_Limb_%2816%29.png/revision/latest/scale-to-width-down/1000?cb=20130123232423',
+        actor: 'Mae Whitman',
+      },
+      {
+        id: 13,
+        name: 'Steve Holt',
+        fullName: 'Steve Holt',
+        aliases: 'Steve',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/b/b4/1x03_Bringing_Up_Buster_%2831%29.png/revision/latest/scale-to-width-down/1000?cb=20120123071546',
+        actor: 'Justin Grant Wade',
+      },
+      {
+        id: 14,
+        name: 'Oscar',
+        fullName: 'Oscar George Bluth',
+        aliases: 'Oscar',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/6/69/2x07_Switch_Hitter_%2812%29.png/revision/latest/scale-to-width-down/1000?cb=20121216214633',
+        actor: 'Jeffrey Tambor',
+      },
+      {
+        id: 15,
+        name: 'Annyong',
+        fullName: "Hel-loh 'Annyong' Bluth",
+        aliases: 'Annyong',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c0/1x18_Missing_Kitty_%2828%29.png/revision/latest/scale-to-width-down/1000?cb=20120819210411',
+        actor: 'Justin Lee',
+      },
+      {
+        id: 16,
+        name: 'J. Walter Weatherman',
+        fullName: 'J. Walter Weatherman',
+        aliases: 'J, The one-armed man',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/6/66/1x10_Pier_Pressure_%2840%29.png/revision/latest/scale-to-width-down/1000?cb=20120229061140',
+        actor: 'Steve Ryan',
+      },
+      {
+        id: 17,
+        name: 'Lucille Austero',
+        fullName: 'Lucille Austero',
+        aliases: 'Lucille 2',
+        pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/7/76/1x08_My_Mother_the_Car_%2833%29.png/revision/latest/scale-to-width-down/1000?cb=20120214071637',
+        actor: 'Liza Minelli',
+      },
+    ];
 
-        const data = await request(app)
-            .get('/characters')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(allChar);
-    });
+    const data = await request(app)
+      .get('/characters')
+      .expect('Content-Type', /json/)
+      .expect(200);
 
-    it('returns the character with the id of 1', async () => {
-        const data = await request(app)
-            .get('/characters/1')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(expect.any(Object));
-    });
+    expect(data.body).toEqual(allChar);
+  });
 
-    it('returns all characters with a name that contains the search query', async () => {
-        const data = await request(app)
-            .get('/characters/search/Michael')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    name: 'Michael',
-                    fullName: 'Michael Bluth',
-                    aliases: 'Nichael Bluth, Chareth Cutestory',
-                    pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/f/f7/1x01_Pilot_%2809%29.png/revision/latest?cb=20120301043946',
-                    actor: 'Jason Bateman',
-                }),
-            ])
-        );
+  it('returns the character with the id of 1', async () => {
+    const data = await request(app)
+      .get('/characters/1')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(data.body).toEqual({
+      id: 1,
+      name: 'Michael',
+      fullName: 'Michael Bluth',
+      aliases: 'Nichael Bluth, Chareth Cutestory',
+      pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/f/f7/1x01_Pilot_%2809%29.png/revision/latest?cb=20120301043946',
+      actor: 'Jason Bateman',
     });
+  });
 
-    it('returns a random character', async () => {
-        const data = await request(app)
-            .get('/characters/random')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(expect.any(Object));
-    });
+  it('returns all characters with a name that contains the search query', async () => {
+    const data = await request(app)
+      .get('/characters/search/Michael')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(data.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Michael',
+          fullName: 'Michael Bluth',
+          aliases: 'Nichael Bluth, Chareth Cutestory',
+          pic: 'https://static.wikia.nocookie.net/arresteddevelopment/images/f/f7/1x01_Pilot_%2809%29.png/revision/latest?cb=20120301043946',
+          actor: 'Jason Bateman',
+        }),
+      ])
+    );
+  });
+
+  it('returns a random character', async () => {
+    const data = await request(app)
+      .get('/characters/random')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(data.body).toEqual(expect.any(Object));
+  });
 });

--- a/__tests__/chicken.test.js
+++ b/__tests__/chicken.test.js
@@ -1,58 +1,58 @@
 require('dotenv').config();
 const fakeRequest = require('supertest');
 const app = require('../lib/app');
-const setup = require('../data/setup');
+const { execSync } = require('child_process');
 const pool = require('../lib/utils/pool');
 
 describe('app routes', () => {
-    beforeEach(() => {
-        return setup(pool);
+  beforeAll(() => {
+    execSync('npm run setup-db');
+  });
+
+  afterAll((done) => {
+    return pool.end(done);
+  });
+  describe('Chicken dance tests', () => {
+    test('returns all chicken dance gifs', async () => {
+      const chickens = [
+        {
+          url: 'https://tv-fanatic-res.cloudinary.com/iu/s--Dx2MU33g--/t_full/cs_srgb,f_auto,fl_strip_profile.lossy,q_auto:420/v1407322355/arrested-development-dancing-gif.gif',
+        },
+        {
+          url: 'https://c.tenor.com/Ggx4JAo3QaIAAAAC/arrested-development-chicken.gif',
+        },
+        {
+          url: 'https://64.media.tumblr.com/tumblr_lj6zc4WwBL1qzwuo3.gif',
+        },
+        {
+          url: 'https://media.tumblr.com/tumblr_lj6zd2mwbo1qzwuo3.gif',
+        },
+        {
+          url: 'https://24.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo2_250.gif',
+        },
+        {
+          url: 'https://24.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo3_250.gif',
+        },
+        {
+          url: 'https://25.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo4_250.gif',
+        },
+        {
+          url: 'https://25.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo1_250.gif',
+        },
+      ];
+      const data = await fakeRequest(app)
+        .get('/chicken')
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(data.body).toEqual(chickens);
     });
 
-    afterAll((done) => {
-        return pool.end(done);
+    test('returns a random chicken dance gif', async () => {
+      const data = await fakeRequest(app)
+        .get('/chicken/random')
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(data.body).toEqual(expect.any(Object));
     });
-    describe.skip('Chicken dance tests', () => {
-        test('returns all chicken dance gifs', async () => {
-            const chickens = [
-                {
-                    url: 'https://tv-fanatic-res.cloudinary.com/iu/s--Dx2MU33g--/t_full/cs_srgb,f_auto,fl_strip_profile.lossy,q_auto:420/v1407322355/arrested-development-dancing-gif.gif',
-                },
-                {
-                    url: 'https://c.tenor.com/Ggx4JAo3QaIAAAAC/arrested-development-chicken.gif',
-                },
-                {
-                    url: 'https://64.media.tumblr.com/tumblr_lj6zc4WwBL1qzwuo3.gif',
-                },
-                {
-                    url: 'https://media.tumblr.com/tumblr_lj6zd2mwbo1qzwuo3.gif',
-                },
-                {
-                    url: 'https://24.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo2_250.gif',
-                },
-                {
-                    url: 'https://24.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo3_250.gif',
-                },
-                {
-                    url: 'https://25.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo4_250.gif',
-                },
-                {
-                    url: 'https://25.media.tumblr.com/tumblr_m2sts9O1BI1r7vuvuo1_250.gif',
-                },
-            ];
-            const data = await fakeRequest(app)
-                .get('/chicken')
-                .expect('Content-Type', /json/)
-                .expect(200);
-            expect(data.body).toEqual(chickens);
-        });
-
-        test('returns a random chicken dance gif', async () => {
-            const data = await fakeRequest(app)
-                .get('/chicken/random')
-                .expect('Content-Type', /json/)
-                .expect(200);
-            expect(data.body).toEqual(expect.any(Object));
-        });
-    });
+  });
 });

--- a/__tests__/quotes.test.js
+++ b/__tests__/quotes.test.js
@@ -1,360 +1,392 @@
 require('dotenv').config();
 const fakeRequest = require('supertest');
 const app = require('../lib/app');
-const setup = require('../data/setup');
+const { execSync } = require('child_process');
 const pool = require('../lib/utils/pool');
 
-describe.skip('app routes', () => {
-    beforeEach(() => {
-        return setup(pool);
-    });
+describe('app routes', () => {
+  beforeAll(() => {
+    execSync('npm run setup-db');
+  });
 
-    afterAll((done) => {
-        return pool.end(done);
-    });
+  afterAll((done) => {
+    return pool.end(done);
+  });
 
-    it('returns all quotes', async () => {
-        const allQuotes = [
-            {
-                quote: "I've made a huge mistake",
-                saidBy: 'Gob',
-            },
-            {
-                quote: "I don't understand the question, and I won't respond to it",
-                saidBy: 'Lucille',
-            },
-            {
-                quote: "I want to cry so bad, but I don't think I can spare the moisture.",
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'Marry  me!',
-                saidBy: 'Maeby',
-            },
-            {
-                quote: "I'm a MONSTER!",
-                saidBy: 'Buster',
-            },
-            {
-                quote: 'You must teach me, George Michael. You must teach me the ways of the secular flesh.',
-                saidBy: 'Ann',
-            },
-            {
-                quote: 'Say goodbye to THESE!',
-                saidBy: 'Kitty',
-            },
-            {
-                quote: 'Steve Holt!',
-                saidBy: 'Steve Holt',
-            },
-            {
-                quote: 'Annyong!',
-                saidBy: 'Annyong',
-            },
-            {
-                quote: 'Oh it’s so cute. She sometimes takes a little pack of mayonnaise and she’ll squirt it in her mouth all over and then she’ll take an egg and kind of mmm mmm. She calls it a mayonegg.',
-                saidBy: 'George Michael',
-            },
-            {
-                quote: 'Excuse me, do these effectively hide my thunder?',
-                saidBy: 'Tobias',
-            },
-            {
-                quote: "The Mere Fact That You Call Making Love 'Pop-Pop' Tells Me You’re Not Ready",
-                saidBy: 'Michael',
-            },
-            {
-                quote: "It's as Ann as the nose on plain's face",
-                saidBy: 'Michael',
-            },
-            {
-                quote: 'Her?',
-                saidBy: 'George',
-            },
-            {
-                quote: 'Way to plant Ann!',
-                saidBy: 'George Michael',
-            },
-            {
-                quote: "I'm sure that Egg is a very nice person. I just don't want you spending all your money getting her all glittered up for Easter.",
-                saidBy: 'Michael',
-            },
-            {
-                quote: "I love all my children equally...[Earlier that day...] I don't care for Gob",
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'I wonder how I can talk you out of ever making that face again',
-                saidBy: 'Michael',
-            },
-            {
-                quote: "I'm afraid I just blue myself",
-                saidBy: 'Tobias',
-            },
-            {
-                quote: "I prematurely shot my wad on what was supposed to be a dry run so now I'm afraid I have something of a mess on my hands.",
-                saidBy: 'Tobias',
-            },
-            {
-                quote: "OH MY GOD THEY'RE HAVING A FIRE...Sale.",
-                saidBy: 'Tobias',
-            },
-            {
-                quote: "Oh, Mercy Me! I Keep Forgetting I'm In The Colonies!",
-                saidBy: 'Tobias',
-            },
-            {
-                quote: 'Okay, Lindsay, Are You Forgetting That I Was A Professional Twice-Over? An Analyst And A Therapist. An Analrapist.',
-                saidBy: 'Tobias',
-            },
-            {
-                quote: 'I mean it’s one banana Michael, what could it cost, $10?',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'Here’s some money. Go see a Star War.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'Everything they do is so dramatic and flamboyant, it just makes me wanna set myself on fire.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'Well I’d rather be dead in California than alive in Arizona.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'She thinks I’m too critical. That’s another fault of hers.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'Suddenly he’s too much of a big shot to brush Mother’s hair.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'She’d love to get at me any way she could. That’s why she’s been flirting with Gob. She’s trying to prove that she’s closer to my children than I am, but the joke’s on her, because she doesn’t know how little I care for Gob',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'Yes I was flying, but a little too close to the sun.',
-                saidBy: 'Buster',
-            },
-            {
-                quote: 'Suddenly playing with yourself is a scholarly pursuit.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'He’s a beautiful boy. They don’t appreciate him. It’s his glasses. They make him look like a lizard. Plus he’s self-conscious.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'If that’s a veiled criticism about me, I won’t hear it and I won’t respond to it.',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: 'You’re Telling Me There’s No Alcohol? What The Hell Are We Supposed To Do For Two Days?',
-                saidBy: 'Lucille',
-            },
-            {
-                quote: "Why can't you be more like Buster? He put himself in a coma to protect this family.",
-                saidBy: 'George',
-            },
-            {
-                quote: 'How dare you? I oughta shave your head and make you sit under that camera all night, mister.',
-                saidBy: 'George',
-            },
-            {
-                quote: 'Never promise crazy a baby',
-                saidBy: 'George',
-            },
-            {
-                quote: "These are dangerous people, Michael. They will do whatever it takes to get inside this family and bring us down....Oh, they're polite and the men all sound gay, but they will rip out your heart. And their breath...",
-                saidBy: 'George',
-            },
-            {
-                quote: "I wine 'em and dine 'em, but I don't let them tell me what to do. (speaking to his dolls, arranged for a tea party) I don't let them tell me what to do.",
-                saidBy: 'George',
-            },
-            {
-                quote: 'If you play me, you got to play me like a man and not like some mincing little Polly or Nellie! I get those names confused. Apology. (to dolls) Apologies all around.',
-                saidBy: 'George',
-            },
-            {
-                quote: "I'm going crazy with the boredom, Michael. At least in prison, we had knife fights and we had movie night and once, both. Those men did not enjoy Soapdish.",
-                saidBy: 'George',
-            },
-            {
-                quote: "Well, of course, you're gonna get hop-ons.",
-                saidBy: 'George',
-            },
-            {
-                quote: "Oh, that is just great. Now, I'm expected to climb back on top of Kitty and do my thing again. I mean, this family runs into problems and it's 'Oh, let's have Gob (bleep) our way out of it.'",
-                saidBy: 'Gob',
-            },
-            {
-                quote: "You were ... you were just a turd out there, you know? You couldn't kick, and you couldn't run, you know? You were just a turd.",
-                saidBy: 'George',
-            },
-            {
-                quote: "You don't fire crazy. You never fire crazy.",
-                saidBy: 'George',
-            },
-            {
-                quote: 'No touching!',
-                saidBy: 'George',
-            },
-            {
-                quote: "And that's why you always leave a note.",
-                saidBy: 'J. Walter Weatherman',
-            },
-            {
-                quote: "And thats why you don't yell.",
-                saidBy: 'J. Walter Weatherman',
-            },
-            {
-                quote: "And thats why you don't teach lessons to your son.",
-                saidBy: 'J. Walter Weatherman',
-            },
-            {
-                quote: "And thats why you don't teach your father a lesson.",
-                saidBy: 'J. Walter Weatherman',
-            },
-            {
-                quote: 'Never promise crazy a baby.',
-                saidBy: 'George',
-            },
-            {
-                quote: 'Daddy horny, Michael',
-                saidBy: 'George',
-            },
-            {
-                quote: 'There absolutely will be a margarita in my mouth!',
-                saidBy: 'Kitty',
-            },
-            {
-                quote: 'Please refrain from discussing or engaging in any sort of inter-office (bleep) or (bleep -ing), or finger (bleep) or (bleep-sting) or (bleep-esting) or even (bleeping), even though so many people in this office are begging for it.',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'Is that George Michael’s girlfriend? What, is she funny or something?',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'She’s not ‘that’ Mexican, mom, she’s my Mexican. And she’s Colombian or something.',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'I hear the jury’s still out on science.',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'Why go to a banana stand when we can make your banana stand?',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'Yeah, the guy in the $3,000 suit is holding the elevator for the guy who doesn’t make that in four months. Come On!',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'Come on!',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'Illusion, Michael. A trick is something a whore does for money… (to kids) or cocaine.',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'Taste the happy, Michael! Taste it!',
-                saidBy: 'Gob',
-            },
-            {
-                quote: 'You taste these tears! You taste my sad, Michael!',
-                saidBy: 'Gob',
-            },
-            {
-                quote: '(about love) I know what an erection feels like, Michael. No, it’s the opposite. It’s like my heart is getting hard.',
-                saidBy: 'Gob',
-            },
-            {
-                quote: "We do a quick vote and it's Ciao, Fathero.",
-                saidBy: 'George Michael',
-            },
-            {
-                quote: '(Opening a present) Quicken Premier! Dad, I hope you kept the receipt.',
-                saidBy: 'George Michael',
-            },
-            {
-                quote: "Don't you see? I drugged him not to go all the way with him.",
-                saidBy: 'Maeby',
-            },
-            {
-                quote: "(about Franklin) I just don't want him to point out my cracker ass in front of Ann.",
-                saidBy: 'George Michael',
-            },
-            {
-                quote: "I had another hearing. I think I'm going to get off. I have a good lawyer.",
-                saidBy: 'Barry',
-            },
-            {
-                quote: 'Does this look contagious to you?',
-                saidBy: 'Barry',
-            },
-            {
-                quote: 'The will is at my office. Next to the hot plate with the frayed wires.',
-                saidBy: 'Barry',
-            },
-            {
-                quote: "You can control your bladder when you're dead.",
-                saidBy: 'Steve Holt',
-            },
-            {
-                quote: "Don't ask 'Can I?' Ask 'I can.'",
-                saidBy: 'Steve Holt',
-            },
-            {
-                quote: "You don't have to worry so much. I mean, obviously your dad doesn't want to spend time with you, but, you know, go to the beach or whatever.",
-                saidBy: 'Maeby',
-            },
-            {
-                quote: "There's always money in the banana stand",
-                saidBy: 'George',
-            },
-        ];
-        const data = await fakeRequest(app)
-            .get('/quotes')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(allQuotes);
-    });
+  it('returns all quotes', async () => {
+    const allQuotes = [
+      {
+        quote: "I've made a huge mistake",
+        saidBy: 'Gob',
+      },
+      {
+        quote: "I don't understand the question, and I won't respond to it",
+        saidBy: 'Lucille',
+      },
+      {
+        quote:
+          "I want to cry so bad, but I don't think I can spare the moisture.",
+        saidBy: 'Lucille',
+      },
+      {
+        quote: 'Marry  me!',
+        saidBy: 'Maeby',
+      },
+      {
+        quote: "I'm a MONSTER!",
+        saidBy: 'Buster',
+      },
+      {
+        quote:
+          'You must teach me, George Michael. You must teach me the ways of the secular flesh.',
+        saidBy: 'Ann',
+      },
+      {
+        quote: 'Say goodbye to THESE!',
+        saidBy: 'Kitty',
+      },
+      {
+        quote: 'Steve Holt!',
+        saidBy: 'Steve Holt',
+      },
+      {
+        quote: 'Annyong!',
+        saidBy: 'Annyong',
+      },
+      {
+        quote:
+          'Oh it’s so cute. She sometimes takes a little pack of mayonnaise and she’ll squirt it in her mouth all over and then she’ll take an egg and kind of mmm mmm. She calls it a mayonegg.',
+        saidBy: 'George Michael',
+      },
+      {
+        quote: 'Excuse me, do these effectively hide my thunder?',
+        saidBy: 'Tobias',
+      },
+      {
+        quote:
+          "The Mere Fact That You Call Making Love 'Pop-Pop' Tells Me You’re Not Ready",
+        saidBy: 'Michael',
+      },
+      {
+        quote: "It's as Ann as the nose on plain's face",
+        saidBy: 'Michael',
+      },
+      {
+        quote: 'Her?',
+        saidBy: 'George',
+      },
+      {
+        quote: 'Way to plant Ann!',
+        saidBy: 'George Michael',
+      },
+      {
+        quote:
+          "I'm sure that Egg is a very nice person. I just don't want you spending all your money getting her all glittered up for Easter.",
+        saidBy: 'Michael',
+      },
+      {
+        quote:
+          "I love all my children equally...[Earlier that day...] I don't care for Gob",
+        saidBy: 'Lucille',
+      },
+      {
+        quote: 'I wonder how I can talk you out of ever making that face again',
+        saidBy: 'Michael',
+      },
+      {
+        quote: "I'm afraid I just blue myself",
+        saidBy: 'Tobias',
+      },
+      {
+        quote:
+          "I prematurely shot my wad on what was supposed to be a dry run so now I'm afraid I have something of a mess on my hands.",
+        saidBy: 'Tobias',
+      },
+      {
+        quote: "OH MY GOD THEY'RE HAVING A FIRE...Sale.",
+        saidBy: 'Tobias',
+      },
+      {
+        quote: "Oh, Mercy Me! I Keep Forgetting I'm In The Colonies!",
+        saidBy: 'Tobias',
+      },
+      {
+        quote:
+          'Okay, Lindsay, Are You Forgetting That I Was A Professional Twice-Over? An Analyst And A Therapist. An Analrapist.',
+        saidBy: 'Tobias',
+      },
+      {
+        quote: 'I mean it’s one banana Michael, what could it cost, $10?',
+        saidBy: 'Lucille',
+      },
+      {
+        quote: 'Here’s some money. Go see a Star War.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote:
+          'Everything they do is so dramatic and flamboyant, it just makes me wanna set myself on fire.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote: 'Well I’d rather be dead in California than alive in Arizona.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote: 'She thinks I’m too critical. That’s another fault of hers.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote: 'Suddenly he’s too much of a big shot to brush Mother’s hair.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote:
+          'She’d love to get at me any way she could. That’s why she’s been flirting with Gob. She’s trying to prove that she’s closer to my children than I am, but the joke’s on her, because she doesn’t know how little I care for Gob',
+        saidBy: 'Lucille',
+      },
+      {
+        quote: 'Yes I was flying, but a little too close to the sun.',
+        saidBy: 'Buster',
+      },
+      {
+        quote: 'Suddenly playing with yourself is a scholarly pursuit.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote:
+          'He’s a beautiful boy. They don’t appreciate him. It’s his glasses. They make him look like a lizard. Plus he’s self-conscious.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote:
+          'If that’s a veiled criticism about me, I won’t hear it and I won’t respond to it.',
+        saidBy: 'Lucille',
+      },
+      {
+        quote:
+          'You’re Telling Me There’s No Alcohol? What The Hell Are We Supposed To Do For Two Days?',
+        saidBy: 'Lucille',
+      },
+      {
+        quote:
+          "Why can't you be more like Buster? He put himself in a coma to protect this family.",
+        saidBy: 'George',
+      },
+      {
+        quote:
+          'How dare you? I oughta shave your head and make you sit under that camera all night, mister.',
+        saidBy: 'George',
+      },
+      {
+        quote: 'Never promise crazy a baby',
+        saidBy: 'George',
+      },
+      {
+        quote:
+          "These are dangerous people, Michael. They will do whatever it takes to get inside this family and bring us down....Oh, they're polite and the men all sound gay, but they will rip out your heart. And their breath...",
+        saidBy: 'George',
+      },
+      {
+        quote:
+          "I wine 'em and dine 'em, but I don't let them tell me what to do. (speaking to his dolls, arranged for a tea party) I don't let them tell me what to do.",
+        saidBy: 'George',
+      },
+      {
+        quote:
+          'If you play me, you got to play me like a man and not like some mincing little Polly or Nellie! I get those names confused. Apology. (to dolls) Apologies all around.',
+        saidBy: 'George',
+      },
+      {
+        quote:
+          "I'm going crazy with the boredom, Michael. At least in prison, we had knife fights and we had movie night and once, both. Those men did not enjoy Soapdish.",
+        saidBy: 'George',
+      },
+      {
+        quote: "Well, of course, you're gonna get hop-ons.",
+        saidBy: 'George',
+      },
+      {
+        quote:
+          "Oh, that is just great. Now, I'm expected to climb back on top of Kitty and do my thing again. I mean, this family runs into problems and it's 'Oh, let's have Gob (bleep) our way out of it.'",
+        saidBy: 'Gob',
+      },
+      {
+        quote:
+          "You were ... you were just a turd out there, you know? You couldn't kick, and you couldn't run, you know? You were just a turd.",
+        saidBy: 'George',
+      },
+      {
+        quote: "You don't fire crazy. You never fire crazy.",
+        saidBy: 'George',
+      },
+      {
+        quote: 'No touching!',
+        saidBy: 'George',
+      },
+      {
+        quote: "And that's why you always leave a note.",
+        saidBy: 'J. Walter Weatherman',
+      },
+      {
+        quote: "And thats why you don't yell.",
+        saidBy: 'J. Walter Weatherman',
+      },
+      {
+        quote: "And thats why you don't teach lessons to your son.",
+        saidBy: 'J. Walter Weatherman',
+      },
+      {
+        quote: "And thats why you don't teach your father a lesson.",
+        saidBy: 'J. Walter Weatherman',
+      },
+      {
+        quote: 'Never promise crazy a baby.',
+        saidBy: 'George',
+      },
+      {
+        quote: 'Daddy horny, Michael',
+        saidBy: 'George',
+      },
+      {
+        quote: 'There absolutely will be a margarita in my mouth!',
+        saidBy: 'Kitty',
+      },
+      {
+        quote:
+          'Please refrain from discussing or engaging in any sort of inter-office (bleep) or (bleep -ing), or finger (bleep) or (bleep-sting) or (bleep-esting) or even (bleeping), even though so many people in this office are begging for it.',
+        saidBy: 'Gob',
+      },
+      {
+        quote:
+          'Is that George Michael’s girlfriend? What, is she funny or something?',
+        saidBy: 'Gob',
+      },
+      {
+        quote:
+          'She’s not ‘that’ Mexican, mom, she’s my Mexican. And she’s Colombian or something.',
+        saidBy: 'Gob',
+      },
+      {
+        quote: 'I hear the jury’s still out on science.',
+        saidBy: 'Gob',
+      },
+      {
+        quote: 'Why go to a banana stand when we can make your banana stand?',
+        saidBy: 'Gob',
+      },
+      {
+        quote:
+          'Yeah, the guy in the $3,000 suit is holding the elevator for the guy who doesn’t make that in four months. Come On!',
+        saidBy: 'Gob',
+      },
+      {
+        quote: 'Come on!',
+        saidBy: 'Gob',
+      },
+      {
+        quote:
+          'Illusion, Michael. A trick is something a whore does for money… (to kids) or cocaine.',
+        saidBy: 'Gob',
+      },
+      {
+        quote: 'Taste the happy, Michael! Taste it!',
+        saidBy: 'Gob',
+      },
+      {
+        quote: 'You taste these tears! You taste my sad, Michael!',
+        saidBy: 'Gob',
+      },
+      {
+        quote:
+          '(about love) I know what an erection feels like, Michael. No, it’s the opposite. It’s like my heart is getting hard.',
+        saidBy: 'Gob',
+      },
+      {
+        quote: "We do a quick vote and it's Ciao, Fathero.",
+        saidBy: 'George Michael',
+      },
+      {
+        quote:
+          '(Opening a present) Quicken Premier! Dad, I hope you kept the receipt.',
+        saidBy: 'George Michael',
+      },
+      {
+        quote: "Don't you see? I drugged him not to go all the way with him.",
+        saidBy: 'Maeby',
+      },
+      {
+        quote:
+          "(about Franklin) I just don't want him to point out my cracker ass in front of Ann.",
+        saidBy: 'George Michael',
+      },
+      {
+        quote:
+          "I had another hearing. I think I'm going to get off. I have a good lawyer.",
+        saidBy: 'Barry',
+      },
+      {
+        quote: 'Does this look contagious to you?',
+        saidBy: 'Barry',
+      },
+      {
+        quote:
+          'The will is at my office. Next to the hot plate with the frayed wires.',
+        saidBy: 'Barry',
+      },
+      {
+        quote: "You can control your bladder when you're dead.",
+        saidBy: 'Steve Holt',
+      },
+      {
+        quote: "Don't ask 'Can I?' Ask 'I can.'",
+        saidBy: 'Steve Holt',
+      },
+      {
+        quote:
+          "You don't have to worry so much. I mean, obviously your dad doesn't want to spend time with you, but, you know, go to the beach or whatever.",
+        saidBy: 'Maeby',
+      },
+      {
+        quote: "There's always money in the banana stand",
+        saidBy: 'George',
+      },
+    ];
+    const data = await fakeRequest(app)
+      .get('/quotes')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(data.body).toEqual(allQuotes);
+  });
 
-    it('returns all quotes for one character by character name', async () => {
-        const data = await fakeRequest(app)
-            .get('/quotes/Lucille')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(expect.any(Array));
-    });
+  it('returns all quotes for one character by character name', async () => {
+    const data = await fakeRequest(app)
+      .get('/quotes/Lucille')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(data.body).toEqual(expect.any(Array));
+  });
 
-    it('returns all quotes by search query', async () => {
-        const data = await fakeRequest(app)
-            .get('/quotes/search/Banana')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    quote: 'I mean it’s one banana Michael, what could it cost, $10?',
-                    saidBy: 'Lucille',
-                }),
-            ])
-        );
-    });
+  it('returns all quotes by search query', async () => {
+    const data = await fakeRequest(app)
+      .get('/quotes/search/Banana')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(data.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          quote: 'I mean it’s one banana Michael, what could it cost, $10?',
+          saidBy: 'Lucille',
+        }),
+      ])
+    );
+  });
 
-    it('returns a random quote', async () => {
-        const data = await fakeRequest(app)
-            .get('/quotes/random')
-            .expect('Content-Type', /json/)
-            .expect(200);
-        expect(data.body).toEqual(expect.any(Object));
-    });
+  it('returns a random quote', async () => {
+    const data = await fakeRequest(app)
+      .get('/quotes/random')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(data.body).toEqual(expect.any(Object));
+  });
 });

--- a/data/load-seed-data.js
+++ b/data/load-seed-data.js
@@ -4,43 +4,58 @@ const quotes = require('./seed-data/quotes.js');
 const chickens = require('./seed-data/chickens.js');
 
 const seedTables = async () => {
-    await characters.map(async (character) => {
-        return await pool.query(
-            `
+  try {
+    await Promise.all(
+      characters.map((character) => {
+        return pool.query(
+          `
             INSERT INTO characters (name, full_name, aliases, pic, actor)
-            VALUES ($1, $2, $3, $4, $5);
-            `,
-            [
-                character.name,
-                character.full_name,
-                character.aliases,
-                character.pic,
-                character.actor,
-            ]
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *;`,
+          [
+            character.name,
+            character.full_name,
+            character.aliases,
+            character.pic,
+            character.actor,
+          ]
         );
-    });
+      })
+    );
 
-    await quotes.map(async (quote) => {
-        return await pool.query(
-            `
+    await Promise.all(
+      quotes.map((quote) => {
+        return pool.query(
+          `
                 INSERT INTO quotes (quote, said_by)
-                VALUES ($1, $2);
+                VALUES ($1, $2)
+                RETURNING *;
                 `,
-            [quote.quote, quote.said_by]
+          [quote.quote, quote.said_by]
         );
-    });
+      })
+    );
 
-    await chickens.map(async (chicken) => {
-        return await pool.query(
-            `
+    await Promise.all(
+      chickens.map((chicken) => {
+        return pool.query(
+          `
                 INSERT INTO chickens (url)
-                VALUES ($1);
+                VALUES ($1)
+                RETURNING *;
                 `,
-            [chicken.url]
+          [chicken.url]
         );
-    });
+      })
+    );
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log(err);
+  }
 };
 
+seedTables();
+
 module.exports = {
-    seedTables,
+  seedTables,
 };

--- a/data/setup.js
+++ b/data/setup.js
@@ -1,11 +1,7 @@
 const fs = require('fs').promises;
-const { seedTables } = require('./load-seed-data.js');
 
 module.exports = (pool) => {
-    return fs
-        .readFile(`${__dirname}/../sql/setup.sql`, { encoding: 'utf-8' })
-        .then((sql) => pool.query(sql))
-        .then(() => {
-            seedTables();
-        });
+  return fs
+    .readFile(`${__dirname}/../sql/setup.sql`, { encoding: 'utf-8' })
+    .then((sql) => pool.query(sql));
 };

--- a/package.json
+++ b/package.json
@@ -1,37 +1,38 @@
 {
-    "name": "arrested-development-show-api",
-    "version": "1.0.0",
-    "description": "An API to get data about the tv show Arrested Development",
-    "main": "server.js",
-    "scripts": {
-        "test": "jest --verbose --runInBand --testLocationInResults --setupFiles dotenv/config --detectOpenHandles",
-        "test:watch": "npm run test -- --watch",
-        "start": "node -r dotenv/config server.js",
-        "start:watch": "nodemon -r dotenv/config server.js",
-        "setup-db": "node -r dotenv/config setup-db.js",
-        "setup-heroku": "heroku run npm run setup-db"
-    },
-    "jest": {
-        "testEnvironment": "node"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-        "@babel/eslint-parser": "^7.15.7",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@types/jest": "^26.0.20",
-        "@types/pg": "^8.6.1",
-        "eslint": "^7.20.0",
-        "jest": "^27.0.4",
-        "nodemon": "^2.0.7",
-        "supertest": "^6.1.3"
-    },
-    "dependencies": {
-        "cors": "^2.8.5",
-        "dotenv": "^8.2.0",
-        "express": "^4.17.1",
-        "pg": "^8.7.1",
-        "superagent": "^6.1.0"
-    }
+  "name": "arrested-development-show-api",
+  "version": "1.0.0",
+  "description": "An API to get data about the tv show Arrested Development",
+  "main": "server.js",
+  "scripts": {
+    "test": "jest --verbose --runInBand --testLocationInResults --setupFiles dotenv/config --detectOpenHandles",
+    "test:watch": "npm run test -- --watch",
+    "start": "node -r dotenv/config server.js",
+    "start:watch": "nodemon -r dotenv/config server.js",
+    "seedTables": "node -r dotenv/config data/load-seed-data.js",
+    "setup-db": "node -r dotenv/config setup-db.js && npm run seedTables",
+    "setup-heroku": "heroku run npm run setup-db"
+  },
+  "jest": {
+    "testEnvironment": "node"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@babel/eslint-parser": "^7.15.7",
+    "@babel/plugin-syntax-class-properties": "^7.12.13",
+    "@types/jest": "^26.0.20",
+    "@types/pg": "^8.6.1",
+    "eslint": "^7.20.0",
+    "jest": "^27.0.4",
+    "nodemon": "^2.0.7",
+    "supertest": "^6.1.3"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1",
+    "pg": "^8.7.1",
+    "superagent": "^6.1.0"
+  }
 }


### PR DESCRIPTION
I was able to clear up the issue with the seed data randomly being added in a different order so that the test cases will pass consistently. I ended up changing the `load-seed-data` file to include `Promise.all` around each of the seed blocks. Then I setup a script in `package.json` to run the `load-seed-data.js` file and added it to the existing `setup-db` script. 

In order to get the tests to pass, though, it was a bit tricky. Ultimately, I ended up using `execSync` to execute a child process that ran the `setup-db` script in each test file using a `beforeAll` method. This seemed to do the trick and all tests are now passing consistently with correct data! 
